### PR TITLE
update node version

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -2,7 +2,7 @@ service: custom-user-pool
 
 provider:
   name: aws
-  runtime: nodejs6.10
+  runtime: nodejs14.x
   stage: dev
   region: us-east-2
 


### PR DESCRIPTION
The runtime parameter of nodejs6.10 is no longer supported for creating or updating AWS Lambda functions